### PR TITLE
docs: Add comprehensive guide on Unity Scene Management

### DIFF
--- a/docs/scene_management_guide.md
+++ b/docs/scene_management_guide.md
@@ -1,0 +1,305 @@
+# A Comprehensive Guide to Scene Management Scripting APIs in Unity 6.1
+## I. Introduction to Scene Management in Unity 6.1
+### A. Overview of Scene Management
+In the Unity game engine, a Scene can be conceptualized as a unique level, area, or distinct segment of a game or application. Each Scene file encapsulates environments, characters, obstacles, user interfaces, and decorations, essentially forming the building blocks of an interactive experience. Effective scene management is paramount for structuring a game logically, optimizing performance through techniques like additive loading and unloading, and streamlining development workflows, particularly in collaborative team environments or for projects involving large, streaming worlds. This guide focuses on the scene management scripting APIs available in Unity, with a primary emphasis on Unity version 6.1, a significant release that continues to refine these capabilities.
+### B. Core Scene Management APIs: Runtime vs. Editor
+Unity provides two primary classes for programmatic scene management, each tailored to a distinct operational context: UnityEngine.SceneManagement.SceneManager for runtime operations and UnityEditor.SceneManagement.EditorSceneManager for editor-specific tasks. A critical aspect of Unity's design is the strict separation between these two: SceneManager is intended for use during Play mode or in a built player, while EditorSceneManager is exclusively for Edit mode operations within the Unity Editor.
+This division is a deliberate design choice that enforces a strong separation of concerns. The engine provides context-specific tools, which inherently reduces the complexity for developers working within each distinct environment and enhances overall engine stability. For instance, EditorSceneManager includes functionalities pertinent to the authoring process, such as saving scenes (SaveScene), marking scenes as modified (MarkSceneDirty), or creating new scenes with editor-specific setups (NewScene). These operations are generally irrelevant or could be detrimental if invoked at runtime. Conversely, SceneManager focuses on operations optimized for game performance and dynamic content delivery, such as asynchronous scene loading (LoadSceneAsync), unloading (UnloadSceneAsync), and creating empty scenes during gameplay (CreateScene). Attempting to use SceneManager functionalities in Edit mode will typically result in an error, guiding the developer to use the appropriate EditorSceneManager API instead. This clear distinction prevents common pitfalls, such as attempting to save a scene asset during runtime (which is not supported), and ensures that each manager is optimized for its specific domain.
+The following table summarizes the key differences and intended use cases for these two fundamental classes:
+**Table 1: SceneManager vs. EditorSceneManager Key Differences**
+| Feature/Capability | UnityEngine.SceneManagement.SceneManager (Runtime) | UnityEditor.SceneManagement.EditorSceneManager (Editor-time) | Notes/Use Case |
+| --- | --- | --- | --- |
+| Availability | Play Mode / Player | Edit Mode Only | Strict separation; using in the wrong context leads to errors. |
+| Scene Loading (Async/Sync) | LoadScene(), LoadSceneAsync() | OpenScene() | Runtime focuses on performance; Editor on authoring. |
+| Scene Unloading | UnloadSceneAsync() | CloseScene() | Runtime for dynamic memory management; Editor for closing assets. |
+| Scene Creation | CreateScene() (empty, at runtime) | NewScene() (with setup options) | Runtime for dynamic generation; Editor for initial scene setup. |
+| Scene Saving | Not Supported | SaveScene(), SaveOpenScenes() | Scenes are assets, saved only in the Editor. |
+| Active Scene Management | GetActiveScene(), SetActiveScene() | GetActiveScene(), SetActiveScene() | Both contexts manage an active scene, but implications differ. |
+| Modifying Scene State (Dirty) | Not Applicable (scenes aren't "saved" at runtime) | MarkSceneDirty(), IsSceneDirty() | Editor tracks unsaved changes to scene assets. |
+| Preview Scenes | Not Supported | NewPreviewScene(), OpenPreviewScene() | For custom editor tools requiring isolated rendering. |
+| Event System | sceneLoaded, sceneUnloaded, activeSceneChanged | sceneOpened, sceneClosed, sceneSaving, sceneDirtied, etc. | Runtime events for game logic; Editor events for tool integration & workflows. |
+
+This table clarifies the distinct roles and highlights the contextual nature of Unity's scene management APIs, guiding developers to use the correct tools for their specific needs.
+### C. Accessing Unity 6.1 Documentation
+To delve deeper into the specifics of any API, developers can access the official Unity documentation. The Unity 6.1 User Manual and Scripting API references are the primary sources of information. Typically, from the main Unity User Manual page, a link to the "Scripting API" is prominently displayed, often in the top navigation bar. The Unity 6 resources hub also aggregates documentation, best practice guides, samples, and tutorials pertinent to the latest version. The "Programming in Unity" section of the manual provides foundational knowledge and links to further learning resources.
+## II. Runtime Scene Management with UnityEngine.SceneManagement.SceneManager
+### A. Overview of SceneManager
+The UnityEngine.SceneManagement.SceneManager class is the cornerstone of managing scenes during gameplay, whether in the Unity Player or during Play mode within the Editor. Its primary responsibilities encompass the dynamic loading and unloading of scenes, the creation of new scenes at runtime, accessing information about currently loaded scenes, and manipulating scene contents, such as moving GameObjects between them.
+### B. Loading Scenes
+SceneManager offers both synchronous and asynchronous methods for loading scenes, each with distinct use cases and performance characteristics.
+#### 1. Synchronous Loading: LoadScene()
+Synchronous scene loading is performed using the LoadScene() method. It has several overloads:
+*   `LoadScene(string sceneName)`: Loads a scene by its name (which can be the simple name without the .unity extension or the full asset path).
+*   `LoadScene(int sceneBuildIndex)`: Loads a scene by its index in the Build Settings.
+Overloads accepting `LoadSceneMode`:
+*   `LoadSceneMode.Single`: This is the default mode if not specified. It unloads all currently loaded scenes before loading the new scene.
+*   `LoadSceneMode.Additive`: Loads the specified scene in addition to any currently loaded scenes, allowing multiple scenes to coexist in the hierarchy.
+A significant caution associated with `LoadScene()` is its synchronous nature. This means the method will block the main game thread, halting all game updates and rendering until the scene loading process is complete. This can lead to noticeable pauses or stutters in gameplay, especially when loading larger or more complex scenes. The documentation explicitly warns about this and recommends using asynchronous loading to avoid such performance hiccups. Furthermore, `LoadScene()` forces any previously initiated asynchronous operations (like an ongoing `LoadSceneAsync`) to complete immediately, even if their `allowSceneActivation` property was set to `false`, which can disrupt carefully managed loading sequences.
+The continued existence of `LoadScene()` likely serves backward compatibility or very simple, non-critical loading scenarios where a brief pause is acceptable. However, for most modern game development, its use is discouraged in favor of its asynchronous counterpart. This reflects a broader shift in game development towards asynchronous operations to maintain application responsiveness and provide a smoother user experience.
+#### 2. Asynchronous Loading: LoadSceneAsync()
+For smoother transitions and better performance, `LoadSceneAsync()` is the highly recommended method for loading scenes at runtime. Its overloads mirror those of `LoadScene()`:
+*   `LoadSceneAsync(string sceneName)`
+*   `LoadSceneAsync(int sceneBuildIndex)`
+*   Overloads accepting `LoadSceneMode` (Single or Additive).
+Unlike `LoadScene()`, `LoadSceneAsync()` performs the loading operation in the background without blocking the main thread. This method returns an `AsyncOperation` object, which is crucial for managing the loading process. The `AsyncOperation` provides:
+*   `isDone` (bool): Indicates if the loading operation (including activation) is complete.
+*   `progress` (float): A value from 0.0 to 1.0 representing the loading progress. Note that progress typically reaches 0.9 when assets are loaded, and 1.0 when the scene is activated.
+*   `allowSceneActivation` (bool): Defaults to `true`. If set to `false`, the scene will load up to 90% and then pause until this property is set back to `true`, allowing developers to control the exact moment of scene activation (e.g., after a loading screen animation finishes or user input).
+*   `completed` (event): An event that fires when the operation is complete.
+Developers typically use `LoadSceneAsync()` within a coroutine to yield execution while waiting for the operation to complete or to update a loading progress bar.
+#### 3. Loading Parameters with LoadSceneParameters
+For more fine-grained control over scene loading, particularly with additive loading, the `LoadSceneParameters` struct can be used with overloads of `LoadScene()` and `LoadSceneAsync()`. This struct allows specifying the `LoadSceneMode` and potentially other future parameters. For example: `var parameters = new LoadSceneParameters(LoadSceneMode.Additive); SceneManager.LoadScene("MyAdditiveScene", parameters);`
+**Table 2: Scene Loading Methods Comparison (SceneManager)**
+| Method Signature | Synchronicity | Use Case/Impact | Key Parameters | Returns |
+| --- | --- | --- | --- | --- |
+| `LoadScene(string/int)` | Synchronous | Simple loading, causes pause. Unloads current scenes. | `sceneName`/`sceneBuildIndex` | `Scene` (if successful) |
+| `LoadScene(string/int, LoadSceneMode)` | Synchronous | Single or Additive loading, causes pause. | `sceneName`/`sceneBuildIndex`, `LoadSceneMode` | `Scene` (if successful) |
+| `LoadScene(string/int, LoadSceneParameters)` | Synchronous | Finer control with parameters, causes pause. | `sceneName`/`sceneBuildIndex`, `LoadSceneParameters` | `Scene` (if successful) |
+| `LoadSceneAsync(string/int)` | Asynchronous | Smooth loading, no pause. Unloads current scenes. Recommended. | `sceneName`/`sceneBuildIndex` | `AsyncOperation` |
+| `LoadSceneAsync(string/int, LoadSceneMode)` | Asynchronous | Single or Additive smooth loading. Recommended. | `sceneName`/`sceneBuildIndex`, `LoadSceneMode` | `AsyncOperation` |
+| `LoadSceneAsync(string/int, LoadSceneParameters)` | Asynchronous | Finer control with parameters, smooth loading. Recommended. | `sceneName`/`sceneBuildIndex`, `LoadSceneParameters` | `AsyncOperation` |
+
+This table provides a clear comparison, reinforcing the advantages of asynchronous methods for maintaining application performance and responsiveness.
+### C. Unloading Scenes: UnloadSceneAsync()
+To remove scenes from memory and the hierarchy at runtime, `SceneManager` provides the `UnloadSceneAsync()` method. This is an asynchronous operation that returns an `AsyncOperation` to track its progress. It has several overloads:
+*   `UnloadSceneAsync(Scene scene)`: Unloads the specified `Scene` object.
+*   `UnloadSceneAsync(string sceneName)`: Unloads a scene by its name or path.
+*   `UnloadSceneAsync(int sceneBuildIndex)`: Unloads a scene by its build index.
+It's important to note that scenes can also be unloaded implicitly. When `LoadScene()` or `LoadSceneAsync()` is called with `LoadSceneMode.Single`, all currently loaded scenes are automatically unloaded before the new scene is loaded. A common pattern is to call `UnloadSceneAsync()` in the `OnDestroy()` method of a `MonoBehaviour` to clean up additively loaded scenes when the "owner" scene or object is destroyed.
+### D. Accessing Loaded Scenes
+`SceneManager` provides several properties and methods to query the state of loaded scenes:
+*   `GetActiveScene()`: Returns a `Scene` struct representing the currently active scene. The active scene is where newly instantiated `GameObject`s are placed by default and whose settings (e.g., lighting, NavMesh) are typically used.
+*   `sceneCount`: A static property returning the number of scenes currently loaded in memory.
+*   `loadedSceneCount`: Similar to `sceneCount`, indicating the number of loaded scenes.
+*   `sceneCountInBuildSettings`: A static property returning the total number of scenes included in the game's Build Settings.
+*   `GetSceneAt(int index)`: Returns the `Scene` struct at the given index in the list of loaded scenes (order of loading).
+*   `GetSceneByPath(string scenePath)`: Searches all loaded scenes and returns the `Scene` struct matching the given asset path.
+*   `GetSceneByName(string name)`: Searches all loaded scenes and returns the `Scene` struct matching the given name.
+*   `GetSceneByBuildIndex(int buildIndex)`: Returns the `Scene` struct corresponding to the given build index.
+A recommended best practice is to load and reference scenes by their path rather than their build index. Build indices can become fragile if the order of scenes in the Build Settings is changed, leading to incorrect scenes being loaded. Using the full asset path (e.g., "Assets/Scenes/Levels/Level01.unity") also prevents ambiguity if multiple scenes happen to share the same name but reside in different folders.
+### E. Manipulating Scenes and GameObjects
+Beyond loading and unloading, `SceneManager` allows for more direct manipulation:
+*   `CreateScene(string sceneName)`: Dynamically creates a new, empty scene at runtime with the given name. This scene is not saved as an asset but exists in memory.
+*   `MergeScenes(Scene sourceScene, Scene destinationScene)`: Merges the contents of the `sourceScene` into the `destinationScene`. All root `GameObject`s from the source scene are moved to the destination scene, and the source scene is then removed.
+*   `MoveGameObjectToScene(GameObject go, Scene scene)`: Moves a specified `GameObject` from its current scene to a target scene. There are important constraints:
+    *   The `GameObject` to be moved must be a root `GameObject` (i.e., it cannot have a parent in its current scene's hierarchy).
+    *   The target `Scene` must already be loaded (e.g., via additive loading).
+    This method is often used in conjunction with `DontDestroyOnLoad` for objects that need to persist across single scene loads, and then be moved into a new additively loaded scene. An example includes loading a new scene additively and then moving a player character or a manager object into it.
+*   `MoveGameObjectsToScene(NativeArray<int> instanceIDs, Scene scene)`: A more recent addition for efficiently moving multiple `GameObject`s (identified by their instance IDs) to a new scene.
+*   `SetActiveScene(Scene scene)`: Sets the specified loaded scene as the active scene.
+The concept of the "Active Scene" is particularly important in multi-scene environments. The active scene dictates default behaviors, such as where newly instantiated `GameObject`s are placed if no specific scene is provided during instantiation. It also determines which scene's lighting settings (like skybox and ambient light from the Lighting window) and NavMesh data are currently in effect. When working with multiple additively loaded scenes, programmatically changing the active scene using `SetActiveScene(Scene scene)` becomes crucial for ensuring predictable behavior. For instance, a game might have a persistent "manager" scene, a "UI" scene, and various "level" scenes loaded additively. Before loading a new level or instantiating level-specific objects, developers might set the corresponding level scene as active to ensure new objects are parented correctly and the correct environmental settings are applied. This makes `SetActiveScene` a pivotal control point for managing complex multi-scene architectures.
+### F. SceneManager Events
+`SceneManager` exposes several events that allow scripts to react to changes in scene state in a decoupled manner:
+*   `activeSceneChanged(Scene current, Scene next)`: Fired when the active scene changes. It provides references to the previous active scene (`current`) and the new active scene (`next`).
+*   `sceneLoaded(Scene scene, LoadSceneMode mode)`: Fired when a scene has finished loading. It provides the `Scene` object that was loaded and the `LoadSceneMode` used.
+*   `sceneUnloaded(Scene scene)`: Fired when a scene has been unloaded. It provides the `Scene` object that was unloaded.
+These events promote a more modular and maintainable codebase. Instead of a central scene loading script needing explicit knowledge of all systems that must react to scene changes, individual systems (e.g., an `AudioManager`, `UIManager`, or `GameplayManager`) can subscribe to these events and perform their own initialization or cleanup logic independently. For example, an `AudioManager` might subscribe to `sceneLoaded` to play scene-specific music or load audio banks, while a `UIManager` might subscribe to `activeSceneChanged` to update UI elements based on the context of the new active scene. This event-driven approach aligns with the Observer design pattern and is a common practice in Unity for creating scalable game systems.
+## III. Editor Scene Management with UnityEditor.SceneManagement.EditorSceneManager
+### A. Overview of EditorSceneManager
+The `UnityEditor.SceneManagement.EditorSceneManager` class provides the API for manipulating scenes specifically within the Unity Editor environment, during Edit mode. It is essential for creating editor tools, automating scene setup workflows, and extending the editor's built-in scene management capabilities. As previously noted, its functionalities are distinct from the runtime `SceneManager` and should not be used in Play mode or in built players.
+### B. Core Functionalities
+`EditorSceneManager` offers a comprehensive suite of methods for scene manipulation in the editor:
+#### Creating and Opening Scenes:
+*   `NewScene(NewSceneSetup setup, NewSceneMode mode)`: Creates a new scene in the editor. `NewSceneSetup` allows specifying whether to create default lighting and game objects (`DefaultGameObjects`) or an empty scene (`EmptyScene`). `NewSceneMode` can be `Single` (replaces current open scenes) or `Additive` (adds the new scene to the hierarchy).
+*   `OpenScene(string scenePath, OpenSceneMode mode = OpenSceneMode.Single)`: Opens an existing scene asset from the given path. `OpenSceneMode.Additive` is particularly important for enabling multi-scene editing workflows directly within the editor, allowing multiple scenes to be loaded and visible in the Hierarchy window simultaneously.
+#### Saving Scenes:
+*   `SaveScene(Scene scene, string dstScenePath = "", bool saveAsCopy = false)`: Saves the specified scene. If `dstScenePath` is provided, it acts as "Save As." If `saveAsCopy` is true, the original scene remains open and unmodified, and a copy is saved.
+*   `SaveOpenScenes()`: Saves all currently open scenes that have unsaved changes.
+*   `SaveCurrentModifiedScenesIfUserWantsTo()`: Prompts the user with a dialog to save any open, modified scenes before proceeding with an operation (e.g., entering Play mode).
+*   `SaveModifiedScenesIfUserWantsTo(Scene[] scenes)`: Similar, but for a specific array of scenes.
+#### Managing Scene State:
+*   `MarkSceneDirty(Scene scene)`: Marks the specified scene as modified (dirty), indicating it has unsaved changes. This typically adds an asterisk next to the scene name in the Hierarchy and Editor title bar.
+*   `MarkAllScenesDirty()`: Marks all currently open scenes as modified.
+While not explicitly listed in the provided text, methods like `IsSceneDirty(string scenePath)` or `Scene.isDirty` (for loaded scenes) are used to check this state.
+#### Scene Hierarchy Manipulation:
+*   `MoveSceneAfter(Scene src, Scene dst)`: Reorders the open scenes in the Hierarchy window, moving the `src` scene to appear immediately after the `dst` scene.
+*   `MoveSceneBefore(Scene src, Scene dst)`: Moves the `src` scene to appear immediately before the `dst` scene.
+#### Preview Scenes:
+*   `NewPreviewScene()`: Creates a new, temporary scene intended for preview purposes (e.g., rendering an asset in isolation for a custom editor window). Objects in preview scenes are not saved and are typically not affected by regular scene lighting.
+*   `OpenPreviewScene(string scenePath)`: Opens an existing scene asset as a preview scene.
+*   `ClosePreviewScene(Scene scene)`: Closes a preview scene and destroys its contents.
+### C. EditorSceneManager Events
+`EditorSceneManager` provides a rich set of events that allow editor scripts to hook into various stages of a scene's lifecycle within the editor. These events are fundamental for creating powerful editor extensions and custom workflows. Key events include:
+*   `activeSceneChangedInEditMode(Scene previousActiveScene, Scene newActiveScene)`
+*   `newSceneCreated(Scene scene, NewSceneSetup setup, NewSceneMode mode)`
+*   `sceneOpened(Scene scene, OpenSceneMode mode)`
+*   `sceneClosed(Scene scene)`
+*   `sceneClosing(Scene scene, bool removingScene)`
+*   `sceneDirtied(Scene scene)`
+*   `sceneSaved(Scene scene)`
+*   `sceneSaving(Scene scene, string path)`
+*   `sceneManagerSetupRestored(SceneSetup[] setup)` (called after the scene setup is restored, e.g., after an assembly reload)
+These events use corresponding delegate types, such as `NewSceneCreatedCallback`, `SceneClosedCallback`, `SceneSavingCallback`, etc..
+The extensive event system within `EditorSceneManager` is pivotal for enhancing editor productivity and enabling sophisticated tool development. Custom editor scripts can subscribe to these events to automate tasks, perform validation, or modify scene content at critical junctures. For example, a script could listen to `sceneSaving` to automatically run a validation check on scene data before the save operation completes, or it could use `sceneOpened` to configure a custom editor layout or initialize tool-specific data relevant to the opened scene. This level of extensibility, driven by a comprehensive event system, is a hallmark of the Unity Editor, allowing developers to tailor the environment to their specific project needs and streamline complex workflows.
+## IV. Understanding Scene Struct and SceneAsset Object
+Interacting with scenes via script often involves two key types: the `Scene` struct, which represents a loaded scene's runtime data, and the `SceneAsset` object, which is an editor-only reference to a scene file.
+### A. The UnityEngine.SceneManagement.Scene Struct
+The `UnityEngine.SceneManagement.Scene` struct is a lightweight data structure that represents a scene that has been loaded into memory, either at runtime or within the editor. It provides properties and methods to inspect and interact with the loaded scene.
+#### Properties of the `Scene` struct :
+*   `buildIndex` (int): Returns the index of the scene in the Build Settings. If the scene is not in the Build Settings (e.g., an additively loaded scene not part of the build list, or a dynamically created scene), this will typically be -1.
+*   `isDirty` (bool): Indicates if the scene has been modified since it was last saved. This is primarily relevant in the editor.
+*   `isLoaded` (bool): Returns `true` if the scene has finished loading and its `GameObject`s have been initialized and enabled.
+*   `name` (string): Returns the name of the scene (e.g., "MyLevel").
+*   `path` (string): Returns the asset path of the scene file (e.g., "Assets/MyScenes/MyLevel.unity"). For scenes not loaded from an asset (e.g., created with `SceneManager.CreateScene`), this path might be empty or reflect its temporary nature.
+*   `rootCount` (int): Returns the number of root `GameObject`s in the scene's hierarchy.
+#### Methods of the `Scene` struct :
+*   `GetRootGameObjects()`: Returns an array of `GameObject` containing all the root `GameObject`s in the scene. This allows iteration over the top-level objects.
+*   `IsValid()`: Returns `true` if the `Scene` struct instance refers to a valid, loaded scene. A `Scene` might be invalid if, for example, an attempt was made to get a scene by a name or path that doesn't exist or couldn't be loaded.
+#### Operators :
+*   `operator == (Scene a, Scene b)`: Compares two `Scene` structs for equality.
+*   `operator != (Scene a, Scene b)`: Compares two `Scene` structs for inequality.
+Instances of the `Scene` struct are typically obtained as return values from methods in `SceneManager` (e.g., `SceneManager.GetActiveScene()`, `SceneManager.GetSceneByName()`) or `EditorSceneManager` (e.g., `EditorSceneManager.OpenScene()`).
+### B. The UnityEditor.SceneAsset Object
+The `UnityEditor.SceneAsset` class is an editor-only type that inherits from `UnityEngine.Object`. Its purpose is to provide a direct reference to a Scene file within the Unity project, as an asset. This is distinct from the `Scene` struct, which represents a loaded scene.
+The primary use of `SceneAsset` is in editor scripting, particularly for creating custom inspectors or editor windows where a user needs to select a scene from the project. It is commonly used as the type for an `EditorGUILayout.ObjectField`. This allows developers to drag and drop a scene file from the Project window onto the field in the Inspector.
+An example provided in the documentation illustrates a `ScenePicker` MonoBehaviour with a string field `scenePath`. A custom editor script for `ScenePicker` uses `EditorGUILayout.ObjectField("scene", oldScene, typeof(SceneAsset), false) as SceneAsset;` to allow the user to assign a scene. When a scene is picked, `AssetDatabase.GetAssetPath(newScene)` is used to retrieve the string path of the selected `SceneAsset`, which is then stored in `scenePath`.
+The `SceneAsset` acts as a crucial bridge between editor-time configuration and runtime logic. It allows developers to create robust, type-safe references to scene files in the Inspector (e.g., on a `ScriptableObject` or a `MonoBehaviour` via a custom editor). The string path obtained from the `SceneAsset` (via `AssetDatabase.GetAssetPath()`) can then be used at runtime with `SceneManager.LoadScene()` or `SceneManager.LoadSceneAsync()` to load the actual scene. This approach is preferable to hardcoding scene names or paths directly in scripts, as it makes the references more resilient to file renaming or moving (as long as the `SceneAsset` reference itself is maintained or the GUID remains intact). This promotes an asset-driven workflow, which is a core paradigm in Unity development, ensuring that scene references are treated as manageable project assets.
+## V. Scene Templates: SceneTemplateAsset and SceneTemplateService
+Unity's Scene Template system provides a powerful way to standardize and accelerate the creation of new scenes, especially in larger projects or team environments. It revolves around the `SceneTemplateAsset` and the `SceneTemplateService`.
+### A. UnityEditor.SceneTemplate.SceneTemplateAsset
+A `SceneTemplateAsset` is a `ScriptableObject` that stores all the necessary information and configurations required to instantiate a new scene based on a predefined template scene. It essentially acts as a blueprint for new scenes.
+#### Key Properties of `SceneTemplateAsset` :
+*   `templateScene` (`SceneAsset`): A reference to the source scene asset that will be copied when the template is instantiated. This is the base content for the new scene.
+*   `dependencies` (List of `DependencyInfo`): This critical property lists other assets that the `templateScene` depends on (e.g., Prefabs, Materials, Textures). For each dependency, it specifies whether the asset should be cloned (a new copy created for the new scene) or referenced (the new scene uses the existing shared asset). This allows for fine-grained control over how shared versus unique assets are handled when new scenes are generated from the template.
+*   `templatePipeline` (`ISceneTemplatePipeline`): A reference to a script that implements the `ISceneTemplatePipeline` interface. This allows developers to execute custom C# code during the instantiation process, enabling programmatic modifications or setup tasks for the newly created scene.
+*   `addToDefaults` (bool): If `true`, this template will appear in the list of default templates in the "New Scene" dialog.
+*   `badge` (`Texture2D`): An icon or badge for the template in UI.
+*   `description` (string): A textual description of the template.
+*   `isValid` (bool): Specifies if the template is valid. Invalid templates typically don't appear in the New Scene dialog.
+*   `preview` (`Texture2D`): A preview image for the template.
+*   `templateName` (string): A user-defined name for the template asset.
+As `SceneTemplateAsset` inherits from `UnityEngine.Object`, it also has access to methods like `Object.Instantiate()`, which can be used to clone the asset itself, though scene instantiation is typically handled by the `SceneTemplateService`.
+### B. UnityEditor.SceneTemplate.SceneTemplateService
+The `UnityEditor.SceneTemplate.SceneTemplateService` is a static utility class responsible for managing the creation and instantiation of `SceneTemplateAsset`s.
+#### Static Methods of `SceneTemplateService` :
+*   `CreateSceneTemplate(string path)`: Creates a new, empty `SceneTemplateAsset` at the specified project path. This template is initially unbound, meaning it doesn't have a `templateScene` assigned.
+*   `CreateTemplateFromScene(SceneAsset sceneAsset, string path)`: Creates a new `SceneTemplateAsset` bound to the specified `sceneAsset`. It automatically extracts the dependencies from the `sceneAsset` and typically sets them to be referenced by default.
+*   `Instantiate(SceneTemplateAsset templateAsset, bool loadAdditively, string newSceneOutputPath = null)`: This is the core method for creating a new scene from a template.
+    *   `templateAsset`: The `SceneTemplateAsset` to instantiate.
+    *   `loadAdditively`: If `true`, the new scene is loaded additively into the current scene hierarchy in the editor. If `false`, it replaces the current open scenes (or opens in a new editor if no scenes are open, depending on editor state).
+    *   `newSceneOutputPath` (optional string): If provided, the newly created scene will be saved as a new scene asset at this project path. If `null` or empty, the new scene is typically created as an unsaved scene in the hierarchy.
+#### Events of `SceneTemplateService` : The service also provides events to hook into the instantiation process:
+*   `newSceneTemplateInstantiating`: An event fired just before a scene template is instantiated. It uses the `NewTemplateInstantiating` delegate type.
+*   `newSceneTemplateInstantiated`: An event fired after a scene template has been successfully instantiated. It uses the `NewTemplateInstantiated` delegate type. The documentation snippet names this delegate and event; while the exact signature isn't detailed, a common pattern for such Unity events suggests parameters like (`SceneTemplateAsset` sourceTemplate, `Scene` scene, `SceneSetupContext` context), providing context about the source template, the newly created scene, and the setup context.
+### C. Customizing Instantiation with ISceneTemplatePipeline
+The `ISceneTemplatePipeline` interface allows for powerful customization of the scene instantiation process. By creating a script that implements this interface and assigning it to a `SceneTemplateAsset`'s `templatePipeline` property, developers can execute custom C# code at various stages of instantiation. This could involve programmatically adding or modifying `GameObject`s, adjusting lighting settings, connecting references, or performing any other setup logic required for the new scene beyond what the base `templateScene` provides.
+The Scene Template system, through `SceneTemplateAsset` and `SceneTemplateService`, provides a robust framework for standardizing scene creation and automating repetitive setup tasks. This is particularly beneficial in large projects where many scenes might share a common structure, set of essential `GameObject`s (like managers or UI canvases), or specific dependency configurations. By defining templates, teams can ensure consistency, reduce manual setup errors, and significantly improve workflow efficiency. The ability to manage dependencies (clone vs. reference) and inject custom logic via `ISceneTemplatePipeline` offers a high degree of flexibility, allowing templates to be adapted to diverse project requirements.
+## VI. Working with Multiple Scenes (Multi-Scene Editing)
+### A. Concept and Benefits
+Unity's multi-scene editing capability allows developers to open, view, and edit multiple scenes simultaneously within the editor, and to manage these scenes programmatically at runtime. This feature is invaluable for a variety of development scenarios, including:
+*   **Creating Large Streaming Worlds:** Different parts of a large game world can be managed as separate scenes and loaded/unloaded additively to manage memory and performance.
+*   **Collaborative Workflows:** Team members can work on different scenes concurrently (e.g., one designer on level geometry, another on lighting in a separate scene) and then combine them.
+*   **Modular Level Design:** Game levels or sections can be built as individual scenes and then assembled or loaded dynamically.
+*   **Separation of Concerns:** Common elements like UI, persistent managers, or lighting setups can be maintained in their own scenes and loaded additively with gameplay scenes.
+### B. Editor Workflow for Multi-Scene Editing
+The Unity Editor provides an intuitive workflow for multi-scene editing:
+*   **Additive Scene Opening:** Scenes can be added to the current hierarchy by right-clicking a scene asset in the Project window and selecting "Open Scene Additive," or by dragging one or more scene assets directly into the Hierarchy window.
+*   **Hierarchy Display:** When multiple scenes are open, each scene's contents are displayed under a distinct "scene divider bar" in the Hierarchy window. This bar shows the scene's name and an asterisk (*) if it has unsaved changes.
+*   **Saving Scenes:** Each modified scene can be saved individually via its context menu in the scene divider bar, or all open modified scenes can be saved simultaneously using `File > Save Scenes` (or `Ctrl/Cmd + S`).
+*   **Active Scene Settings:** Certain global settings, such as `RenderSettings` (e.g., skybox, ambient light), `LightmapSettings`, and `NavMesh` settings, are taken from the currently active scene. The active scene is typically displayed in bold in the Hierarchy.
+*   **Baking Data:** Data like Occlusion Culling, Lightmaps, and NavMesh can be baked for multiple open scenes simultaneously. The baked data is often stored relative to the active scene, and references are added to all affected open scenes.
+### C. Scripting for Multiple Scenes
+Programmatic control over multiple scenes is primarily achieved using the `SceneManager` for runtime operations and `EditorSceneManager` for editor scripting.
+#### Runtime Multi-Scene Management:
+*   The core method for loading scenes additively at runtime is `SceneManager.LoadSceneAsync(sceneNameOrPath, LoadSceneMode.Additive)`. This loads the new scene without unloading existing ones.
+*   Similarly, `SceneManager.UnloadSceneAsync()` is used to remove specific additively loaded scenes.
+*   A practical example is loading different parts of a game world as the player moves, or loading a UI scene on top of a gameplay scene.
+#### Editor Multi-Scene Scripting:
+*   `EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive)` allows scripts to open scenes additively within the editor environment.
+#### Accessing and Manipulating:
+*   The `Scene` struct and its properties (`name`, `path`, `isLoaded`, etc.) are used to identify and manage individual scenes within a multi-scene setup.
+*   `SceneManager.MoveGameObjectToScene(gameObject, targetScene)` is essential for transferring `GameObject`s between different loaded scenes, for example, to move a player object from a persistent scene into a newly loaded level scene.
+#### Communication Between Scenes:
+Since scenes are somewhat isolated, direct references between `GameObject`s in different scenes can be challenging to manage, especially if scenes are loaded and unloaded dynamically. Common strategies for inter-scene communication include:
+*   **Singleton Managers:** A globally accessible manager object (often marked with `DontDestroyOnLoad`) can facilitate communication or provide access to shared systems. The provided text alludes to this with the concept of a "central script to handle all of these global sort of variables."
+*   **ScriptableObjects:** `ScriptableObject` assets can hold shared data or act as event channels that `GameObject`s in different scenes can subscribe to or reference.
+*   **Event Systems:** Custom event systems or Unity's built-in `UnityEvents` can be used to broadcast messages that objects in any loaded scene can listen for. The text mentions the use of service locators and event buses for communication in multi-scene setups.
+It's important to note that while cross-scene references are generally prevented in Edit mode to maintain asset integrity, they are allowed in Play mode because scenes cannot be saved at runtime.
+Multi-scene editing, powerfully augmented by additive loading and robust scripting APIs like `SceneManager` and `EditorSceneManager`, facilitates the development of truly modular game architectures. This modularity allows development teams to work on discrete components of a game—such as UI, specific gameplay levels, or lighting configurations—independently. These components can then be seamlessly combined, loaded, and unloaded at runtime. This approach is not only crucial for managing the complexity of large-scale projects but also enables more efficient resource utilization (by only loading necessary parts of the game world) and promotes parallel development efforts, ultimately leading to more scalable and maintainable game projects. Tutorials and examples demonstrate practical applications, such as dynamically loading segments of a larger environment or ensuring scenes are not loaded multiple times if already present.
+## VII. Finding GameObjects in Scenes
+Locating `GameObject`s within a scene or across multiple scenes programmatically is a common requirement. Unity provides several methods for this, each with its own characteristics and performance implications.
+### A. GameObject.Find(string name)
+`GameObject.Find(string name)` searches for an active `GameObject` by its exact name.
+*   If the provided name string contains a forward slash ('/'), it is treated as a path, allowing the method to traverse the `GameObject` hierarchy (e.g., "Parent/Child/Grandchild").
+*   When multiple scenes are loaded and active, `GameObject.Find()` will extend its search across all these loaded scenes to find a matching `GameObject`.
+*   **Performance Warning:** This method can be computationally expensive, especially in large or complex scenes with many `GameObject`s, or when multiple scenes are loaded. The documentation strongly advises against using `GameObject.Find()` in per-frame methods like `Update()`. Instead, it is recommended to call it once (e.g., in `Awake()` or `Start()`) and cache the returned `GameObject` reference for later use.
+A typical use case is for automatically establishing references between `GameObject`s at load time, for instance, a script finding its associated UI elements when the scene starts.
+### B. GameObject.FindWithTag(string tag) / GameObject.FindGameObjectsWithTag(string tag)
+*   `GameObject.FindWithTag(string tag)` returns a single active `GameObject` that has the specified tag. If multiple `GameObject`s have the tag, it returns one of them (the specific one is not guaranteed).
+*   `GameObject.FindGameObjectsWithTag(string tag)` returns an array of all active `GameObject`s that are tagged with the specified tag. If no `GameObject`s have the tag, it returns an empty array.
+*   **Tag Declaration:** Tags must be declared in Unity's Tag Manager (`Edit > Project Settings > Tags and Layers`) before they can be used with these methods. Using an undeclared tag will result in an exception.
+*   **Performance:** While generally considered more performant than `GameObject.Find()` when searching for multiple objects or when the name is not unique, these methods still involve iterating through `GameObject`s. For frequent access, caching the results (especially the array from `FindGameObjectsWithTag`) is recommended.
+*   **Multi-Scene Behavior:** While the documentation for `FindGameObjectsWithTag` does not explicitly detail its behavior with multiple scenes, the behavior of `GameObject.Find()` (searching all loaded scenes ) and the general description of finding active `GameObject`s imply that `FindGameObjectsWithTag` will also search across all currently loaded and active scenes. Third-party documentation also supports this interpretation for active `GameObject`s.
+### C. Transform.Find(string name)
+`Transform.Find(string name)` searches for a child `Transform` by name, but its search is localized to the direct children of the `Transform` on which the method is called. It does not search the entire scene.
+*   This method is often more efficient than `GameObject.Find()` when the target `GameObject` is known to be a child of a specific parent `Transform`, as the search space is much smaller.
+### D. Other Methods (FindAnyObjectByType, FindFirstObjectByType, FindObjectsByType)
+These static methods are inherited from `UnityEngine.Object` and are not specific to `GameObject` but are relevant for finding objects in scenes:
+*   `FindAnyObjectByType<T>()` / `FindFirstObjectByType<T>()`: Retrieves an active loaded object of the specified type `T`.
+*   `FindObjectsByType<T>(FindObjectsSortMode sortMode)`: Retrieves a list of all active loaded objects of type `T`. These can be useful for finding instances of specific script components (e.g., manager scripts) or other Unity object types within the loaded scenes.
+### E. Best Practices for Finding GameObjects
+The choice of method for finding `GameObject`s significantly impacts performance and code maintainability.
+*   **Avoid Frequent Find Calls:** Minimize calls to any `Find` methods (especially `GameObject.Find` and `GameObject.FindGameObjectsWithTag`) within `Update()`, `FixedUpdate()`, or other frequently executed code blocks.
+*   **Cache References:** The most common and effective optimization is to find objects once in `Awake()` or `Start()` and store the references in member variables for reuse.
+*   **Direct Inspector References:** Whenever possible, assign references directly in the Unity Inspector by creating public or `[SerializeField]` private fields in scripts and dragging the target `GameObject`s or components onto these fields. This is the most performant method as it involves no searching at runtime.
+*   **Manager Patterns/Service Locators:** For commonly accessed systems or objects, consider implementing a singleton manager or a service locator pattern. These can provide centralized, efficient access points without repeated searching.
+The trade-off between the convenience of dynamic finding methods and their performance cost is a recurring theme. While methods like `GameObject.Find()` offer flexibility by decoupling object references (useful when prefabs are instantiated dynamically or scene structures change), this flexibility comes at the price of runtime search overhead. Unity's API design and official documentation consistently guide developers towards mitigating this cost through caching or by favoring more direct and performant referencing techniques, such as Inspector assignments. Understanding this trade-off is key to writing efficient and scalable Unity applications.
+**Table 3: GameObject.Find vs. Alternatives**
+| Method | Search Scope | Searches Across Scenes? | Performance Cost | Recommendation | Typical Use Case |
+| --- | --- | --- | --- | --- | --- |
+| `GameObject.Find(string name)` | Entire hierarchy of all loaded scenes | Yes | High, especially in complex/multiple scenes | Avoid frequent use; cache result. | Initial setup in `Awake()`/`Start()`; finding unique named objects. |
+| `GameObject.FindWithTag(string tag)` | All active `GameObject`s in all loaded scenes | Yes (implied) | Moderate; better than `Find()` for non-unique names | Cache result if used often. | Finding a single representative `GameObject` with a specific tag. |
+| `GameObject.FindGameObjectsWithTag(string tag)` | All active `GameObject`s in all loaded scenes | Yes (implied) | Moderate to High (returns array); iterates all | Cache result (array) if used often. | Finding all `GameObject`s with a specific tag (e.g., all enemies, all pickups). |
+| `Transform.Find(string childName)` | Direct children of the specific `Transform` | No (local to `Transform`) | Low | Preferred for finding known children. | Finding a specific child of a known parent `GameObject`. |
+| `Object.FindObjectOfType<T>()` | All active `GameObject`s for component type `T` | Yes | Moderate to High | Use sparingly; cache result. | Finding a unique manager script or component instance. |
+| `Object.FindObjectsOfType<T>()` | All active `GameObject`s for component type `T` | Yes | High (returns array) | Use sparingly; cache result. | Finding all instances of a specific component type. |
+| Direct Inspector Assignment | N/A (reference pre-assigned) | N/A | Negligible (direct access) | Highly Recommended whenever possible. | Linking `GameObject`s/components that are known at edit-time. |
+
+## VIII. Best Practices and Further Learning
+### A. Summary of Key Best Practices for Scene Management Scripting
+Effective scene management is crucial for developing robust, performant, and maintainable Unity projects. Based on the APIs and functionalities discussed, several best practices emerge:
+*   **Prioritize Asynchronous Operations:** At runtime, always prefer asynchronous methods like `SceneManager.LoadSceneAsync()` and `SceneManager.UnloadSceneAsync()` over their synchronous counterparts to prevent game freezes and ensure smooth transitions.
+*   **Use Full Paths for Scene Identification:** When loading scenes by name or path using `SceneManager`, use the full asset path (e.g., "Assets/Scenes/MyLevel.unity") to avoid ambiguity if multiple scenes share the same name and to make references more robust than build indices.
+*   **Cache Find Operation Results:** Avoid calling `GameObject.Find()`, `FindGameObjectsWithTag()`, or `FindObjectOfType()` repeatedly in performance-critical code like `Update()`. Instead, call them once in `Awake()` or `Start()` and cache the returned references. Direct Inspector assignments are the most performant way to establish references.
+*   **Leverage Multi-Scene Editing:** Utilize multi-scene editing workflows and additive loading (`LoadSceneMode.Additive`) for creating modular game worlds, managing large environments, and facilitating collaborative development.
+*   **Utilize Scene Templates for Standardization:** For projects requiring many scenes with similar base setups, `SceneTemplateAsset` and `SceneTemplateService` can standardize creation, ensure consistency, and automate setup tasks, significantly improving workflow efficiency.
+*   **Maintain Clear Separation of Editor and Runtime Logic:** Strictly adhere to using `EditorSceneManager` for editor-specific scripting and `SceneManager` for runtime scene operations to prevent errors and leverage context-specific optimizations.
+*   **Employ Events for Decoupled Communication:** Use the event systems provided by `SceneManager` (e.g., `sceneLoaded`, `activeSceneChanged`) and `EditorSceneManager` to create decoupled communication channels between different game systems or editor tools, leading to more modular and maintainable code.
+### B. Official Unity Resources for Deeper Learning
+Unity provides a wealth of resources for developers looking to deepen their understanding of scene management and other scripting topics:
+*   **Unity Learn Platform:** This is a primary resource offering guided learning pathways, in-depth courses, and specific tutorials on a wide range of Unity features. Topics often include scene management, Addressable Assets for efficient content (including scene) loading, and general scripting best practices.
+*   **Unity User Manual and Scripting API Documentation:** The official documentation remains the definitive source for detailed information on every Unity class, method, and property, including those related to scene management. The Unity 6 resources hub is a good starting point.
+*   **Best Practice Guides:** Unity publishes various best practice guides covering topics like project organization, version control, modular architecture with `ScriptableObject`s, and performance optimization, many of which are relevant to effective scene management. For instance, guides on project organization can help structure scene assets logically, and those on modular architecture often touch upon multi-scene strategies.
+*   **Unity Forums and Community:** The Unity forums and broader community are valuable resources for asking questions, sharing solutions, and learning from the experiences of other developers.
+## IX. Conclusion
+Robust scene management is a foundational element of successful Unity development. A thorough understanding and proficient application of Unity 6.1's scene management scripting APIs—including `UnityEngine.SceneManagement.SceneManager` for runtime control, `UnityEditor.SceneManagement.EditorSceneManager` for editor tooling, the `Scene` struct and `SceneAsset` object for scene representation, and the `SceneTemplateAsset` system for standardized creation—are essential for building scalable, performant, and maintainable interactive experiences.
+By adhering to best practices such as prioritizing asynchronous operations, utilizing multi-scene workflows for modularity, managing `GameObject` references efficiently, and leveraging the appropriate APIs for runtime versus editor contexts, developers can significantly enhance their productivity and the quality of their projects. The clear separation of concerns in Unity's API design, the provision of event-driven mechanisms, and the tools for both granular control and high-level abstraction empower developers to tackle projects of any complexity. Continued exploration of Unity's documentation, learning resources, and evolving features will ensure that developers can harness the full potential of the engine's scene management capabilities.
+## Works cited
+1.  Work with multiple scenes in Unity - Unity - Manual, https://docs.unity3d.com/6000.1/Documentation/Manual/MultiSceneEditing.html
+2.  UNITY 6 TUTORIAL PART 1 - LEARN THE BASICS - HOW TO MAKE A GAME FOR BEGINNERS - YouTube, https://www.youtube.com/watch?v=HwI90YLqMaY
+3.  Multi-Scene editing - Unity - Manual, https://docs.unity3d.com/2020.1/Documentation/Manual/MultiSceneEditing.html
+4.  Scripting API: SceneManager - Unity - Manual, https://docs.unity3d.com/6000.1/Documentation/ScriptReference/SceneManagement.SceneManager.html
+5.  Unity - Manual: Unity 6.1 User Manual, https://docs.unity3d.com/6000.1/Documentation/Manual/UnityManual.html
+6.  Scripting API: GameObject.FindGameObjectsWithTag - Unity, https://docs.unity3d.com/6000.1/Documentation/ScriptReference/GameObject.FindGameObjectsWithTag.html
+7.  Scripting API: EditorSceneManager - Unity, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneManagement.EditorSceneManager.html
+8.  Unity 6 Resources Hub: Docs, Samples, and Tutorials, https://unity.com/campaign/unity-6-resources
+9.  Manual: Programming in Unity, https://docs.unity3d.com/6000.1/Documentation/Manual/scripting.html
+10. SceneManager.LoadScene - Unity - Manual, https://docs.unity3d.com/6000.1/Documentation/ScriptReference/SceneManagement.SceneManager.LoadScene.html
+11. Scripting API: SceneManagement.LoadSceneMode.Additive - Unity - Manual, https://docs.unity3d.com/6000.1/Documentation/ScriptReference/SceneManagement.LoadSceneMode.Additive.html
+12. Scripting API: SceneManagement.SceneManager ... - Unity, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneManagement.SceneManager.MoveGameObjectToScene.html
+13. Multi-Scene editing - Unity User Manual 2021.3 (LTS), https://docs.unity.cn/2021.1/Documentation/Manual/MultiSceneEditing.html
+14. Scene - Scripting API - Unity - Manual, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneManagement.Scene.html
+15. SceneAsset - Scripting API - Unity - Manual, https://docs.unity3d.com/ScriptReference/SceneAsset.html
+16. Scripting API: SceneAsset - Unity, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneAsset.html
+17. Scripting API: SceneTemplateAsset - Unity - Manual, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneTemplate.SceneTemplateAsset.html
+18. Class SceneTemplateAsset | Scene Template | 1.0.0-preview.11, https://docs.unity.cn/Packages/com.unity.scene-template@1.0/api/UnityEditor.SceneTemplate.SceneTemplateAsset.html
+19. Scripting API: SceneTemplateService - Unity, https://docs.unity3d.com/6000.0/Documentation/ScriptReference/SceneTemplate.SceneTemplateService.html
+20. Best practices for organizing your Unity project, https://unity.com/how-to/organizing-your-project
+21. Additive Async Multi-Scene Loading in Unity - YouTube, https://www.youtube.com/watch?v=JFP-cCFID7o&pp=0gcJCfcAhR29_xXO
+22. How to work with multiple scenes in Unity - YouTube, https://www.youtube.com/watch?v=zObWVOv1GlE
+23. How to Send Variables Between Scenes in Unity - YouTube, https://www.youtube.com/watch?v=pMXJv9zzkGg
+24. Scripting API: GameObject.Find - Unity - Manual, https://docs.unity3d.com/ScriptReference/GameObject.Find.html
+25. GameObject - Build Your Own Worlds | Highrise Create, https://create.highrise.game/learn/studio-api/classes/GameObject
+26. Unity Learn: Learn game development w/ Unity | Courses & tutorials ..., https://learn.unity.com/
+27. Advanced best practice guides - Unity - Manual, https://docs.unity3d.com/6000.1/Documentation/Manual/best-practice-guides.html
+28. Explore Unity's best practices, https://unity.com/how-to


### PR DESCRIPTION
This commit introduces a new documentation file, `scene_management_guide.md`, to the `docs` directory.

The guide provides a detailed overview of the Scene Management scripting APIs in Unity 6.1, covering both runtime (`SceneManager`) and editor-time (`EditorSceneManager`) functionalities. It includes explanations of synchronous and asynchronous scene loading, multi-scene editing, and best practices for finding GameObjects and managing scene lifecycles.

This documentation will serve as a valuable resource for developers working on the project, helping to standardize scene management practices and improve workflow efficiency.