### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/simply-ministry/Milehigh.world/security/code-scanning/1](https://github.com/simply-ministry/Milehigh.world/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block that grants only the minimal scopes required for the job. For a typical build-and-test .NET workflow that just checks out code and runs `dotnet` commands, `contents: read` is sufficient. This can be set at the workflow root (applies to all jobs) or at the job level; here we will add it at the job level to align directly with the CodeQL highlight on the `build` job.

Concretely, in `.github/workflows/dotnet.yml`, under the `build:` job definition (around line 13) and before `runs-on: ubuntu-latest` (line 15), insert a `permissions:` mapping with `contents: read`. No imports or additional methods are needed; this is purely a YAML configuration change and does not alter existing build/test logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
